### PR TITLE
Fixed Forge 28.1.37+ Bug

### DIFF
--- a/src/main/java/com/gmail/rohzek/dive/lib/Reference.java
+++ b/src/main/java/com/gmail/rohzek/dive/lib/Reference.java
@@ -14,5 +14,5 @@ public class Reference
 	public static final String RESOURCEID = MODID + ":";
 	
 	// For really relevant anymore. This will stick around just for internal change tracking
-	public static final String VERSION = "3.0.2";
+	public static final String VERSION = "3.0.3";
 }

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "A mod for adding diving gear",
-        "pack_format": 4
+        "pack_format": 4,
         "_comment": "No comment."
     }
 }


### PR DESCRIPTION
Missed a comma in the pack.mcmeta file, which caused it to not be compiled. Previously, this didn't seem to matter, but as of Forge 28.1.37 and newer, this caused a lack of texture and translation files being loaded.